### PR TITLE
remove show and edit button

### DIFF
--- a/src/app/configs/ngadmin-cfg.js
+++ b/src/app/configs/ngadmin-cfg.js
@@ -18,7 +18,7 @@ angular.module('MisterXAdmin')
       nga.field('lat'),
       nga.field('lng')
     ])
-    .listActions(['show', 'edit', 'delete']);
+    .listActions(['delete']);
    admin.addEntity(locations);
 
   // users service


### PR DESCRIPTION
There is no more info and locations can be deleted with the checkboxes (and editing a past location is useless)
